### PR TITLE
Audio improvements

### DIFF
--- a/mediadecoder/decoder.py
+++ b/mediadecoder/decoder.py
@@ -289,11 +289,6 @@ class Decoder(object):
                         fps=audio_fps, nbytes=audio_nbytes,
                         nchannels=audio_nchannels)
                     self.clip.audio.nchannels=audio_nchannels
-                else:
-                    self.clip = VideoFileClip(
-                        mediafile, audio=play_audio,
-                        target_resolution=target_resolution,
-                        audio_fps=audio_fps, audio_nbytes=audio_nbytes)
 
                 logger.debug("Loaded {0}".format(mediafile))
                 return True

--- a/mediadecoder/soundrenderers/pygamerenderer.py
+++ b/mediadecoder/soundrenderers/pygamerenderer.py
@@ -2,6 +2,7 @@ import time
 import threading
 import warnings
 
+
 try:
     # Python 3
     from queue import Queue, Empty
@@ -17,7 +18,7 @@ queue_timeout = 0.01
 class SoundrendererPygame(threading.Thread, SoundRenderer):
     """Uses pygame.mixer to play sound"""
 
-    def __init__(self, audioformat, queue=None):
+    def __init__(self, audioformat, queue=None, pygame_buffersize=None):
         """Constructor.
         Creates a pygame sound renderer using pygame.mixer.
 
@@ -25,9 +26,12 @@ class SoundrendererPygame(threading.Thread, SoundRenderer):
         ----------
         audioformat : dict
                 A dictionary containing the properties of the audiostream
-        queue : Queue.queue
+        queue : Queue.queue, optional
                 A queue object which serves as a buffer on which the individual
-                audio frames are placed by the decoder.
+                audio frames are placed by the decoder (default=None).
+        pygame_buffersize : int, optional
+                The buffersize to be used in the Pygame mixer (default=None).
+
         """
         global pygame
         import pygame
@@ -43,17 +47,31 @@ class SoundrendererPygame(threading.Thread, SoundRenderer):
 
         fps = audioformat["fps"]
         nchannels = audioformat["nchannels"]
-        nbytes = audioformat["nbytes"]
-        buffersize = audioformat["buffersize"]
+        self._nbytes = nbytes = audioformat["nbytes"]
+        if pygame_buffersize:
+            buffersize = pygame_buffersize
+        else:
+            buffersize = audioformat["buffersize"]
 
         if pygame.mixer.get_init() is None:
-            pygame.mixer.init(fps, -8 * nbytes, nchannels, buffersize)
+            if nbytes in (1, 2):
+                fmt = -8 * nbytes
+            elif nbytes == 4:
+                fmt = 32
+            pygame.mixer.init(fps, fmt, nchannels, buffersize)
             self._own_mixer = True
         else:
             self._own_mixer = False
 
     def run(self):
         """Main thread function."""
+        global pygame
+        import pygame
+
+        import numpy as np
+
+        pygame_mixer_unsigned = pygame.mixer.get_init()[1] > 0
+
         if not hasattr(self, "queue"):
             raise RuntimeError("Audio queue is not intialized.")
 
@@ -64,6 +82,21 @@ class SoundrendererPygame(threading.Thread, SoundRenderer):
             if chunk is None:
                 try:
                     frame = self.queue.get(timeout=queue_timeout)
+
+                    # Moviepy only supports 8, 16 and 32 bit signed integer.
+                    # Pygame also supports 8 and 16 bit unsigned integer, as
+                    # well as 32 bit floating point. In case the Pygame mixer
+                    # uses one of those formats, we need to convert each audio
+                    # frame to that on the fly.
+                    if pygame_mixer_unsigned:  # signed int --> unsigned int
+                        if self._nbytes == 1:
+                            frame = frame.astype(np.uint8) + 128
+                        if self._nbytes == 2:
+                            frame = frame.astype(np.uint16) + 32768
+                    if self._nbytes == 4:  # signed int --> float
+                        frame = (frame.astype(np.float32) /
+                                 np.iinfo(np.int32).max)
+
                     chunk = pygame.sndarray.make_sound(frame)
                 except Empty:
                     continue


### PR DESCRIPTION
- cleaned up accessibility of Decoder attributes
- added option to ask for custom `audio_fps`, `audio_nbytes` and `audio_nchannels` when loading media from file
- added option to ask for custom `target_resolution` when loading media from file
- added option to set Moviepy VideoFileClip directly (for custom external clip processing before playing with mediadecoder)
- added parameter `pygame_buffersize` to PygameSoundrenderer init (for using a Pygame mixer buffersize smaller than the size of one video frame, which will improve video/audio synchronization)
- added conversion of audio to unsigned int if Pygame mixer uses this format
- added conversion of 32 bit int to 32 bit float if Pygame mixer uses this format
- fix/hack for 8-bit audio bug in MoviePy (see https://github.com/Zulko/moviepy/issues/2397)