### PR TITLE
Pygame soundrenderer fix & custom pygame mixer challenge ID

### DIFF
--- a/mediadecoder/__init__.py
+++ b/mediadecoder/__init__.py
@@ -1,6 +1,6 @@
 """Media-decoding library based on MoviePy"""
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"
 __author__ = "Daniel Schreij"
 __license__ = "MIT"
 

--- a/mediadecoder/soundrenderers/pygamerenderer.py
+++ b/mediadecoder/soundrenderers/pygamerenderer.py
@@ -92,7 +92,6 @@ class SoundrendererPygame(threading.Thread, SoundRenderer):
         last_channel_state_change = None
         self.keep_listening = True
         while self.keep_listening:
-            start_time = time.perf_counter()
             if chunk is None:
                 try:
                     frame = self.queue.get(timeout=queue_timeout)
@@ -135,7 +134,8 @@ class SoundrendererPygame(threading.Thread, SoundRenderer):
                         if now - last_channel_state_change > \
                                 2 * chunk.get_length():
                             channel.play(chunk)
-            time.sleep(max(0, 0.005 - (time.perf_counter() - start_time)))
+
+            time.sleep(0.005)
 
         if not channel is None and pygame.mixer.get_init():
             channel.stop()


### PR DESCRIPTION
- Fixed a bug where Pygame channel object could get "stuck" for some reason, where it has something queued up but wouldn't advance to it, effectively stopping audio
- Added possibility to set specific pygame mixer channel for usage via "pygame_channel_id" keyword.